### PR TITLE
[chore] Update goteo refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The v4 API
 This repository holds the code for the Goteo **v4** API.
 
-> **NOTE**: Review the trusted certificates by OpenSSL. See: https://github.com/GoteoFoundation/v4/issues/43
+> **NOTE**: Review the trusted certificates by OpenSSL. See: https://github.com/goteo/org.goteo.api/issues/43
 
 ## Installation
 This application requires [Docker](https://docs.docker.com/get-docker/) and the [Docker Compose](https://docs.docker.com/compose/install/) plugin.
@@ -9,8 +9,8 @@ This application requires [Docker](https://docs.docker.com/get-docker/) and the 
 ### 1. Clone or download this repository.
 
 ```shell
-git clone https://github.com/GoteoFoundation/v4
-cd v4
+git clone https://github.com/goteo/org.goteo.api
+cd org.goteo.api
 ```
 
 ### 2. Build the Docker containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: docker/php/Dockerfile
       target: dev
-    container_name: goteo-v4-php
+    container_name: goteo-api-php
     volumes:
       - .:/app
       - ./docker/php/conf.d/openssl.ini:/usr/local/etc/php/conf.d/openssl.ini:ro
@@ -12,7 +12,7 @@ services:
 
   nginx:
     image: nginx:alpine
-    container_name: goteo-v4-nginx
+    container_name: goteo-api-nginx
     volumes:
       - .:/app
       - ./docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
@@ -24,7 +24,7 @@ services:
 
   mariadb:
     image: mariadb:10.11.2
-    container_name: goteo-v4-mariadb
+    container_name: goteo-api-mariadb
     volumes:
       - mariadb-data:/var/lib/mysql
     environment:


### PR DESCRIPTION
Removed outdated references to "GoteoFoundation" in the repo address and "v4" as standalone app name in favor of "api".