### PR TITLE
[GV4] 043 gatewaycharge get filters

### DIFF
--- a/src/ApiResource/Gateway/ChargeApiResource.php
+++ b/src/ApiResource/Gateway/ChargeApiResource.php
@@ -2,8 +2,10 @@
 
 namespace App\ApiResource\Gateway;
 
+use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
+use ApiPlatform\Metadata\ApiFilter;
 use App\ApiResource\Accounting\AccountingApiResource;
 use App\Entity\Gateway\Charge;
 use App\Entity\Money;
@@ -20,6 +22,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     provider: ApiResourceStateProvider::class
 )]
 #[API\Get()]
+#[API\GetCollection()]
+#[ApiFilter(RangeFilter::class, properties: ['money.amount'])]
 class ChargeApiResource
 {
     #[API\ApiProperty(writable: false, identifier: true)]

--- a/src/ApiResource/Gateway/ChargeApiResource.php
+++ b/src/ApiResource/Gateway/ChargeApiResource.php
@@ -2,7 +2,7 @@
 
 namespace App\ApiResource\Gateway;
 
-use ApiPlatform\Doctrine\Orm\Filter as Filter;
+use ApiPlatform\Doctrine\Orm\Filter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
 use App\ApiResource\Accounting\AccountingApiResource;

--- a/src/ApiResource/Gateway/ChargeApiResource.php
+++ b/src/ApiResource/Gateway/ChargeApiResource.php
@@ -2,11 +2,9 @@
 
 namespace App\ApiResource\Gateway;
 
-use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
-use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
+use ApiPlatform\Doctrine\Orm\Filter as Filter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
-use ApiPlatform\Metadata\ApiFilter;
 use App\ApiResource\Accounting\AccountingApiResource;
 use App\Entity\Gateway\Charge;
 use App\Entity\Money;
@@ -24,8 +22,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 #[API\Get()]
 #[API\GetCollection()]
-#[ApiFilter(RangeFilter::class, properties: ['money.amount'])]
-#[ApiFilter(SearchFilter::class, properties: ['money.amount' => 'exact'])]
 class ChargeApiResource
 {
     #[API\ApiProperty(writable: false, identifier: true)]
@@ -65,5 +61,7 @@ class ChargeApiResource
      * It is money before fees and taxes, not accountable.
      */
     #[Assert\NotBlank()]
+    #[API\ApiFilter(Filter\RangeFilter::class, properties: ['money.amount'])]
+    #[API\ApiFilter(Filter\SearchFilter::class, properties: ['money.amount' => 'exact'])]
     public Money $money;
 }

--- a/src/ApiResource/Gateway/ChargeApiResource.php
+++ b/src/ApiResource/Gateway/ChargeApiResource.php
@@ -3,6 +3,7 @@
 namespace App\ApiResource\Gateway;
 
 use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
 use ApiPlatform\Metadata\ApiFilter;
@@ -24,6 +25,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[API\Get()]
 #[API\GetCollection()]
 #[ApiFilter(RangeFilter::class, properties: ['money.amount'])]
+#[ApiFilter(SearchFilter::class, properties: ['money.amount' => 'exact'])]
 class ChargeApiResource
 {
     #[API\ApiProperty(writable: false, identifier: true)]


### PR DESCRIPTION
This PR adds the ability to filter gateway charges based on money amount. While this implementation works, I believe the API endpoints could be improved in terms of readability to better follow RESTful conventions.

**Proposed API changes:**
Currently, the API uses query parameters in the form of:

```
/v4/gateway_charges?money.amount[gt]={number}  
/v4/gateway_charges?money.amount={number}
/v4/gateway_charges?money.amount[lt]={number}
```
A more conventional RESTful approach would be:

```
/v4/gateway_charges?min_amount={number}  
/v4/gateway_charges?amount={number}
/v4/gateway_charges?max_amount={number}
``` 
This change would enhance the API’s intuitiveness and usability.