### PR TITLE
[fix] UserToken deleting

### DIFF
--- a/src/ApiResource/User/UserTokenApiResource.php
+++ b/src/ApiResource/User/UserTokenApiResource.php
@@ -6,6 +6,7 @@ use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
 use App\Dto\UserTokenLoginDto;
 use App\Entity\User\UserToken;
+use App\State\ApiResourceStateProcessor;
 use App\State\ApiResourceStateProvider;
 use App\State\User\UserTokenLoginProcessor;
 
@@ -19,6 +20,7 @@ use App\State\User\UserTokenLoginProcessor;
     shortName: 'UserToken',
     stateOptions: new Options(entityClass: UserToken::class),
     provider: ApiResourceStateProvider::class,
+    processor: ApiResourceStateProcessor::class,
 )]
 #[API\Post(input: UserTokenLoginDto::class, processor: UserTokenLoginProcessor::class)]
 #[API\Get(security: 'is_granted("USER_OWNED", object)')]

--- a/src/Entity/User/UserToken.php
+++ b/src/Entity/User/UserToken.php
@@ -5,7 +5,9 @@ namespace App\Entity\User;
 use App\Entity\Interface\UserOwnedInterface;
 use App\Entity\Trait\TimestampedCreationEntity;
 use App\Entity\Trait\UserOwnedTrait;
+use App\Mapping\Provider\EntityMapProvider;
 use App\Repository\User\UserTokenRepository;
+use AutoMapper\Attribute\MapProvider;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -17,6 +19,7 @@ use Doctrine\ORM\Mapping as ORM;
  * `oat_` means the token was created via an OAuth flow.\
  * `pat_` means the token was created via a login flow.
  */
+#[MapProvider(EntityMapProvider::class)]
 #[ORM\Entity(repositoryClass: UserTokenRepository::class)]
 class UserToken implements UserOwnedInterface
 {


### PR DESCRIPTION
The `UserToken` api resource was showing apparently correct deletion behaviour on DELETE requests, but when inspecting the database the underlying record was still present in the user_tokens table.

The api resource was lacking a state processor that could actually perform the delete operation and the entity was not configured to be properly mapped to it's api resource class counterpart.

This PR fixes that. 