### PR TITLE
[fix] ProjectSupport patch

### DIFF
--- a/src/ApiResource/Gateway/CheckoutApiResource.php
+++ b/src/ApiResource/Gateway/CheckoutApiResource.php
@@ -8,7 +8,6 @@ use App\ApiResource\Accounting\AccountingApiResource;
 use App\Entity\Gateway\Checkout;
 use App\Gateway\CheckoutStatus;
 use App\Gateway\Link;
-use App\Gateway\LinkType;
 use App\Gateway\Tracking;
 use App\Mapping\Transformer\GatewayNameMapTransformer;
 use App\State\ApiResourceStateProvider;
@@ -80,7 +79,8 @@ class CheckoutApiResource
      * @var Link[]
      */
     #[API\ApiProperty(writable: false)]
-    #[MapFrom(transformer: [self::class, 'parseLinks'])]
+    #[MapTo(Checkout::class, transformer: [self::class, 'parseLinks'])]
+    #[MapFrom(Checkout::class, transformer: [self::class, 'parseLinks'])]
     public array $links = [];
 
     /**
@@ -89,30 +89,17 @@ class CheckoutApiResource
      * @var Tracking[]
      */
     #[API\ApiProperty(writable: false)]
-    #[MapFrom(transformer: [self::class, 'parseTrackings'])]
+    #[MapTo(Checkout::class, transformer: 'parseTrackings')]
+    #[MapFrom(Checkout::class, transformer: 'parseTrackings')]
     public array $trackings = [];
 
     public static function parseLinks(array $values)
     {
-        return \array_map(function ($value) {
-            $link = new Link();
-            $link->href = $value['href'];
-            $link->rel = $value['rel'];
-            $link->method = $value['method'];
-            $link->type = LinkType::tryFrom($value['type']);
-
-            return $link;
-        }, $values);
+        return \array_map(fn($value) => Link::tryFrom($value), $values);
     }
 
     public static function parseTrackings(array $values)
     {
-        return \array_map(function ($value) {
-            $tracking = new Tracking();
-            $tracking->title = $value['title'];
-            $tracking->value = $value['value'];
-
-            return $tracking;
-        }, $values);
+        return \array_map(fn($value) => Tracking::tryFrom($value), $values);
     }
 }

--- a/src/ApiResource/Project/SupportApiResource.php
+++ b/src/ApiResource/Project/SupportApiResource.php
@@ -64,7 +64,8 @@ class SupportApiResource
     /**
      * User's will to have their support to the Project be shown publicly.
      */
-    #[Assert\NotBlank()]
+    #[Assert\NotNull()]
+    #[Assert\Type('bool')]
     public bool $anonymous = true;
 
     /**

--- a/src/Entity/Gateway/Checkout.php
+++ b/src/Entity/Gateway/Checkout.php
@@ -229,6 +229,8 @@ class Checkout
 
     public function addLink(Link $link): static
     {
+        $this->removeLink($link);
+
         $this->links = [...$this->links, $link];
 
         return $this;
@@ -266,6 +268,8 @@ class Checkout
 
     public function addTracking(Tracking $tracking): static
     {
+        $this->removeTracking($tracking);
+
         $this->trackings = [...$this->trackings, $tracking];
 
         return $this;

--- a/src/Gateway/Link.php
+++ b/src/Gateway/Link.php
@@ -27,4 +27,15 @@ class Link
      * `payment` links are for end-users who must visit this link to complete the checkout.
      */
     public LinkType $type;
+
+    public static function tryFrom(array $value): Link
+    {
+        $link = new Link();
+        $link->href = $value['href'];
+        $link->rel = $value['rel'];
+        $link->method = $value['method'];
+        $link->type = LinkType::tryFrom($value['type']);
+
+        return $link;
+    }
 }

--- a/src/Gateway/Tracking.php
+++ b/src/Gateway/Tracking.php
@@ -17,4 +17,13 @@ class Tracking
      */
     #[Assert\NotBlank()]
     public string $value;
+
+    public static function tryFrom($value): Tracking
+    {
+        $tracking = new Tracking();
+        $tracking->title = $value['title'];
+        $tracking->value = $value['value'];
+
+        return $tracking;
+    }
 }


### PR DESCRIPTION
Fixed several issues regarding the patching of `ProjectSupport` resources.

- [x] `NotBlank` constraint not allowing to pass `false` values to _anonymous_ property, but the property is a boolean which might be `false`.
- [x] Ultra weird bug where the `AutoMapper` service used `add*` method for `Checkout` links and trackings when patching a `ProjectSupport`, causing the entity's links and trackings to exponentially grow each patch operation.