### PR TITLE
[fix] GatewayCheckout Tracking bad type

### DIFF
--- a/src/Entity/Gateway/Checkout.php
+++ b/src/Entity/Gateway/Checkout.php
@@ -239,7 +239,7 @@ class Checkout
     public function removeLink(Link $link): static
     {
         $this->links = \array_filter(
-            $this->links,
+            \array_map(fn($l) => Link::tryFrom($l), $this->links),
             function (Link $existingLink) use ($link) {
                 return $existingLink->href !== $link->href;
             }
@@ -278,7 +278,7 @@ class Checkout
     public function removeTracking(Tracking $tracking): static
     {
         $this->trackings = \array_filter(
-            $this->trackings,
+            \array_map(fn($t) => Tracking::tryFrom($t), $this->trackings),
             function (Tracking $existingTracking) use ($tracking) {
                 return $existingTracking->title !== $tracking->title
                     && $existingTracking->value !== $tracking->value;

--- a/src/Gateway/Link.php
+++ b/src/Gateway/Link.php
@@ -30,7 +30,9 @@ class Link
 
     public static function tryFrom($value): Link
     {
-        if ($value instanceof Link) return $value;
+        if ($value instanceof Link) {
+            return $value;
+        }
 
         $link = new Link();
         $link->href = $value['href'];

--- a/src/Gateway/Link.php
+++ b/src/Gateway/Link.php
@@ -28,8 +28,10 @@ class Link
      */
     public LinkType $type;
 
-    public static function tryFrom(array $value): Link
+    public static function tryFrom($value): Link
     {
+        if ($value instanceof Link) return $value;
+
         $link = new Link();
         $link->href = $value['href'];
         $link->rel = $value['rel'];

--- a/src/Gateway/Paypal/PaypalGateway.php
+++ b/src/Gateway/Paypal/PaypalGateway.php
@@ -148,7 +148,7 @@ class PaypalGateway extends AbstractGateway
         return new Response();
     }
 
-    private function handleOrderCompleted(array $event)
+    private function handleOrderCompleted(array $event): Response
     {
         $orderId = $event['resource']['id'];
 
@@ -167,6 +167,8 @@ class PaypalGateway extends AbstractGateway
         }
 
         $checkout = $this->checkoutService->chargeCheckout($checkout);
+
+        return new JsonResponse(['checkout' => $checkout]);
     }
 
     private function getPaypalMoney(Charge $charge): array

--- a/src/Gateway/Tracking.php
+++ b/src/Gateway/Tracking.php
@@ -20,6 +20,8 @@ class Tracking
 
     public static function tryFrom($value): Tracking
     {
+        if ($value instanceof Tracking) return $value;
+
         $tracking = new Tracking();
         $tracking->title = $value['title'];
         $tracking->value = $value['value'];

--- a/src/Gateway/Tracking.php
+++ b/src/Gateway/Tracking.php
@@ -20,7 +20,9 @@ class Tracking
 
     public static function tryFrom($value): Tracking
     {
-        if ($value instanceof Tracking) return $value;
+        if ($value instanceof Tracking) {
+            return $value;
+        }
 
         $tracking = new Tracking();
         $tracking->title = $value['title'];


### PR DESCRIPTION
Adds defenses against a weird bug where the Trackings and Links in a GatewayCheckout are sometimes arrays and sometimes instances of `Tracking|Link`.