### PR TITLE
GV4-089 Add Checkout Refund Flag

### DIFF
--- a/src/Entity/Gateway/Checkout.php
+++ b/src/Entity/Gateway/Checkout.php
@@ -8,6 +8,7 @@ use App\Entity\Trait\TimestampedCreationEntity;
 use App\Entity\Trait\TimestampedUpdationEntity;
 use App\Gateway\CheckoutStatus;
 use App\Gateway\Link;
+use App\Gateway\RefundStrategy;
 use App\Gateway\Tracking;
 use App\Mapping\Provider\EntityMapProvider;
 use App\Repository\Gateway\CheckoutRepository;
@@ -66,6 +67,12 @@ class Checkout
     #[SupportedChargeTypes()]
     #[ORM\OneToMany(mappedBy: 'checkout', targetEntity: Charge::class, cascade: ['persist'])]
     private Collection $charges;
+
+    /**
+     * The strategy to refund the payment.
+     */
+    #[ORM\Column(enumType: RefundStrategy::class)]
+    private ?RefundStrategy $refundStrategy = null;
 
     /**
      * The address to where the user must be redirected to.
@@ -176,6 +183,18 @@ class Checkout
                 $charge->setCheckout(null);
             }
         }
+
+        return $this;
+    }
+
+    public function getRefundStrategy(): ?RefundStrategy
+    {
+        return $this->refundStrategy;
+    }
+
+    public function setRefundStrategy(?RefundStrategy $refundStrategy): static
+    {
+        $this->refundStrategy = $refundStrategy;
 
         return $this;
     }

--- a/src/Gateway/GatewayInterface.php
+++ b/src/Gateway/GatewayInterface.php
@@ -64,4 +64,12 @@ interface GatewayInterface
      * @return Response A Response object to send back to the gateway
      */
     public function handleWebhook(Request $request): Response;
+
+    /**
+     * Process a partial refund based on failed project charges in a checkout.
+     * The method should use the refund strategy defined in the Checkout.
+     *
+     * @param Checkout $checkout the checkout containing refund strategy and charges
+     */
+    public function processRefund(Checkout $checkout): void;
 }

--- a/src/Gateway/RefundStrategy.php
+++ b/src/Gateway/RefundStrategy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Gateway;
+
+enum RefundStrategy: string
+{
+    case ToPaymentMethod = 'to_payment_method';
+    case ToWallet = 'to_wallet';
+}


### PR DESCRIPTION
I defined the property as an enum to prioritize flexibility and make it easier to support additional refund strategies in the future. However, I also considered using a bool, since there are currently only two possible refund behaviors, which would simplify the implementation and potentially improve performance.