### PR TITLE
[feat] Projects slug

### DIFF
--- a/config/packages/stof_doctrine_extensions.yaml
+++ b/config/packages/stof_doctrine_extensions.yaml
@@ -7,3 +7,4 @@ stof_doctrine_extensions:
             translatable: true
             loggable: true
             timestampable: true
+            sluggable: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,6 +59,10 @@ services:
             - '%env(STRIPE_API_KEY)%'
             - '%env(STRIPE_WEBHOOK_SECRET)%'
 
+    App\Identifier\IdOrSlugUriVariableTransformer:
+        tags:
+            - { name: api_platform.uri_variables.transformer }
+
     App\Service\Auth\AuthService:
         arguments:
             - '%env(APP_SECRET)%'

--- a/src/ApiResource/Project/ProjectApiResource.php
+++ b/src/ApiResource/Project/ProjectApiResource.php
@@ -19,6 +19,7 @@ use App\Entity\Project\ProjectVideo;
 use App\Mapping\Transformer\BudgetMapTransformer;
 use App\State\ApiResourceStateProvider;
 use App\State\Project\ProjectStateProcessor;
+use App\State\Project\ProjectStateProvider;
 use AutoMapper\Attribute\MapFrom;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -37,11 +38,12 @@ use Symfony\Component\Validator\Constraints as Assert;
     security: 'is_granted("ROLE_USER")',
 )]
 #[API\Get(
+    provider: ProjectStateProvider::class,
     uriTemplate: '/projects/{idOrSlug}',
     uriVariables: [
         'idOrSlug' => new API\Link(
             description: 'Project identifier or slug',
-        )
+        ),
     ]
 )]
 #[API\Patch(

--- a/src/ApiResource/Project/ProjectApiResource.php
+++ b/src/ApiResource/Project/ProjectApiResource.php
@@ -36,7 +36,14 @@ use Symfony\Component\Validator\Constraints as Assert;
     processor: ProjectStateProcessor::class,
     security: 'is_granted("ROLE_USER")',
 )]
-#[API\Get()]
+#[API\Get(
+    uriTemplate: '/projects/{idOrSlug}',
+    uriVariables: [
+        'idOrSlug' => new API\Link(
+            description: 'Project identifier or slug',
+        )
+    ]
+)]
 #[API\Patch(
     input: ProjectUpdationDto::class,
     processor: ProjectStateProcessor::class,

--- a/src/ApiResource/Project/ProjectApiResource.php
+++ b/src/ApiResource/Project/ProjectApiResource.php
@@ -50,6 +50,10 @@ class ProjectApiResource
     #[API\ApiProperty(identifier: true, writable: false)]
     public int $id;
 
+    #[API\ApiProperty(writable: false)]
+    #[API\ApiFilter(SearchFilter::class, strategy: 'exact')]
+    public string $slug;
+
     /**
      * The Accounting holding the funds raised by this Project.
      */

--- a/src/ApiResource/Project/RewardApiResource.php
+++ b/src/ApiResource/Project/RewardApiResource.php
@@ -5,6 +5,7 @@ namespace App\ApiResource\Project;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
+use App\ApiResource\LocalizedApiResourceTrait;
 use App\Entity\Money;
 use App\Entity\Project\Reward;
 use App\State\ApiResourceStateProvider;
@@ -23,6 +24,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 class RewardApiResource
 {
+    use LocalizedApiResourceTrait;
+
     #[API\ApiProperty(identifier: true, writable: false)]
     public int $id;
 

--- a/src/Benzina/ProjectsPump.php
+++ b/src/Benzina/ProjectsPump.php
@@ -60,6 +60,7 @@ class ProjectsPump implements PumpInterface
         $project = new Project();
         $project->setTranslatableLocale($record['lang']);
         $project->setTitle($record['name']);
+        $project->setSlug($record['id']);
         $project->setSubtitle($record['subtitle']);
         $project->setCategory($this->getProjectCategory($record));
         $project->setTerritory($this->getProjectTerritory($record));

--- a/src/Entity/Gateway/Charge.php
+++ b/src/Entity/Gateway/Charge.php
@@ -5,7 +5,6 @@ namespace App\Entity\Gateway;
 use App\Entity\Accounting\Accounting;
 use App\Entity\Accounting\Transaction;
 use App\Entity\Money;
-use App\Entity\Project\Support;
 use App\Entity\Trait\TimestampedCreationEntity;
 use App\Entity\Trait\TimestampedUpdationEntity;
 use App\Gateway\ChargeStatus;
@@ -81,9 +80,6 @@ class Charge
     #[ORM\JoinTable(name: 'checkout_charge_transaction')]
     #[ORM\ManyToMany(targetEntity: Transaction::class, cascade: ['persist'])]
     private Collection $transactions;
-
-    #[ORM\ManyToOne(inversedBy: 'charges')]
-    private ?Support $support = null;
 
     /**
      * The status of the charge with the Gateway.
@@ -195,18 +191,6 @@ class Charge
     public function removeTransaction(Transaction $transaction): static
     {
         $this->transactions->removeElement($transaction);
-
-        return $this;
-    }
-
-    public function getSupport(): ?Support
-    {
-        return $this->support;
-    }
-
-    public function setSupport(?Support $support): static
-    {
-        $this->support = $support;
 
         return $this;
     }

--- a/src/Entity/Project/Project.php
+++ b/src/Entity/Project/Project.php
@@ -73,6 +73,7 @@ class Project implements UserOwnedInterface, AccountingOwnerInterface, Localized
      * The description body for the Project.
      */
     #[ORM\Column(type: Types::TEXT)]
+    #[Gedmo\Translatable()]
     private ?string $description = null;
 
     /**

--- a/src/Entity/Project/Project.php
+++ b/src/Entity/Project/Project.php
@@ -43,6 +43,10 @@ class Project implements UserOwnedInterface, AccountingOwnerInterface, Localized
     #[Gedmo\Translatable()]
     private ?string $title = null;
 
+    #[ORM\Column(length: 56, unique: true)]
+    #[Gedmo\Slug(fields: ['title'])]
+    private ?string $slug = null;
+
     /**
      * Secondary head-line for the project.
      */
@@ -151,6 +155,18 @@ class Project implements UserOwnedInterface, AccountingOwnerInterface, Localized
     public function setTitle(string $title): static
     {
         $this->title = $title;
+
+        return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): static
+    {
+        $this->slug = $slug;
 
         return $this;
     }

--- a/src/Entity/Project/Reward.php
+++ b/src/Entity/Project/Reward.php
@@ -3,6 +3,7 @@
 namespace App\Entity\Project;
 
 use App\Entity\Money;
+use App\Entity\Trait\LocalizedEntityTrait;
 use App\Mapping\Provider\EntityMapProvider;
 use App\Repository\Project\RewardRepository;
 use AutoMapper\Attribute\MapProvider;
@@ -10,6 +11,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 /**
  * A ProjectReward is something the Project owner wishes to give in exchange for contributions to their Project.
@@ -19,6 +21,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: RewardRepository::class)]
 class Reward
 {
+    use LocalizedEntityTrait;
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
@@ -29,9 +33,11 @@ class Reward
     private ?Project $project = null;
 
     #[ORM\Column(length: 255)]
+    #[Gedmo\Translatable()]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
+    #[Gedmo\Translatable()]
     private ?string $description = null;
 
     /**

--- a/src/Entity/Project/Support.php
+++ b/src/Entity/Project/Support.php
@@ -32,7 +32,10 @@ class Support
     /**
      * @var Collection<int, Charge>
      */
-    #[ORM\OneToMany(targetEntity: Charge::class, mappedBy: 'support')]
+    #[ORM\JoinTable(name: 'project_support_charges')]
+    #[ORM\JoinColumn(name: 'support_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: 'charge_id', referencedColumnName: 'id')]
+    #[ORM\ManyToMany(targetEntity: Charge::class)]
     private Collection $charges;
 
     #[ORM\Column]
@@ -87,7 +90,6 @@ class Support
     {
         if (!$this->charges->contains($charge)) {
             $this->charges->add($charge);
-            $charge->setSupport($this);
         }
 
         return $this;
@@ -95,12 +97,7 @@ class Support
 
     public function removeCharge(Charge $charge): static
     {
-        if ($this->charges->removeElement($charge)) {
-            // set the owning side to null (unless already changed)
-            if ($charge->getSupport() === $this) {
-                $charge->setSupport(null);
-            }
-        }
+        $this->charges->removeElement($charge);
 
         return $this;
     }

--- a/src/Entity/Project/Update.php
+++ b/src/Entity/Project/Update.php
@@ -10,6 +10,7 @@ use App\Repository\Project\UpdateRepository;
 use AutoMapper\Attribute\MapProvider;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 
 #[MapProvider(EntityMapProvider::class)]
 #[ORM\Table(name: 'project_update')]
@@ -30,12 +31,15 @@ class Update
     private ?Project $project = null;
 
     #[ORM\Column(length: 255)]
+    #[Gedmo\Translatable()]
     private ?string $title = null;
 
     #[ORM\Column(length: 255)]
+    #[Gedmo\Translatable()]
     private ?string $subtitle = null;
 
     #[ORM\Column(type: Types::TEXT)]
+    #[Gedmo\Translatable()]
     private ?string $body = null;
 
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]

--- a/src/Identifier/IdOrSlugUriVariableTransformer.php
+++ b/src/Identifier/IdOrSlugUriVariableTransformer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Identifier;
+
+use ApiPlatform\Metadata\UriVariableTransformerInterface;
+
+class IdOrSlugUriVariableTransformer implements UriVariableTransformerInterface
+{
+    public function transform(mixed $value, array $types, array $context = [])
+    {
+        if (\is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return (string) $value;
+    }
+
+    public function supportsTransformation(mixed $value, array $types, array $context = []): bool
+    {
+        return \array_key_exists('idOrSlug', $context['uri_variables_map']);
+    }
+}

--- a/src/OpenApi/OpenApiMetadataTrait.php
+++ b/src/OpenApi/OpenApiMetadataTrait.php
@@ -19,34 +19,26 @@ trait OpenApiMetadataTrait
         $resource = $operation->getTags()[0];
 
         $operationType = $this->getOperationType($operation);
-        $operationSummary = $operation->getSummary();
         $operationDescription = $operation->getDescription();
 
         switch ($operationType) {
             case 'collection':
-                $operationSummary = sprintf('List all %ss', $resource);
                 break;
             case 'post':
-                $operationSummary = sprintf('Create one %s', $resource);
                 $operationDescription = sprintf('Creates a new %s resource.', $resource);
                 break;
             case 'get':
-                $operationSummary = sprintf('Retrieve one %s', $resource);
                 $operationDescription = sprintf('Retrieves one %s resource.', $resource);
                 break;
             case 'put':
-                $operationSummary = sprintf('Update one %s', $resource);
                 break;
             case 'delete':
-                $operationSummary = sprintf('Delete one %s', $resource);
                 break;
             case 'patch':
-                $operationSummary = sprintf('Patch one %s', $resource);
                 break;
         }
 
         return $operation
-            ->withSummary($operationSummary)
             ->withDescription($operationDescription);
     }
 

--- a/src/Repository/Project/ProjectRepository.php
+++ b/src/Repository/Project/ProjectRepository.php
@@ -31,6 +31,15 @@ class ProjectRepository extends ServiceEntityRepository
             ->getOneOrNullResult();
     }
 
+    public function findOneByIdOrSlug(mixed $idOrSlug): ?Project
+    {
+        if (\is_numeric($idOrSlug)) {
+            return $this->find($idOrSlug);
+        }
+
+        return $this->findOneBy(['slug' => $idOrSlug]);
+    }
+
     //    /**
     //     * @return Project[] Returns an array of Project objects
     //     */

--- a/src/State/Project/ProjectStateProvider.php
+++ b/src/State/Project/ProjectStateProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\State\Project;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Project\ProjectApiResource;
+use App\Mapping\AutoMapper;
+use App\Repository\Project\ProjectRepository;
+
+class ProjectStateProvider implements ProviderInterface
+{
+    public function __construct(
+        private ProjectRepository $projectRepository,
+        private AutoMapper $autoMapper,
+    ) {}
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        $project = $this->projectRepository->findOneByIdOrSlug($uriVariables['idOrSlug']);
+
+        if ($project === null) {
+            return null;
+        }
+
+        return $this->autoMapper->map($project, ProjectApiResource::class);
+    }
+}


### PR DESCRIPTION
Added `slug` property to Projects. Up to 56 characters to keep project URLs short.

Newly created Projects will get their slug automatically generated from the title.
Projects can be retrieved via `GET /projects/<id-or-slug>`.