### PR TITLE
[feat] Money totalizers

### DIFF
--- a/.env
+++ b/.env
@@ -35,7 +35,6 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 ###> doctrineencryptbundle/doctrine-encrypt-bundle ###
-DOCTRINE_ENCRYPT_KEY=""
 CRYPTO_SECRET=""
 ###< doctrineencryptbundle/doctrine-encrypt-bundle ###
 
@@ -51,6 +50,10 @@ PAYPAL_CLIENT_ID=""
 PAYPAL_CLIENT_SECRET=""
 PAYPAL_WEBHOOK_ID="WEBHOOK_ID"
 ###< App\Gateway\Paypal\PaypalGateway ###
+
+###> App\Money\MoneyService ###
+CURRENCY_DEFAULT="EUR"
+###< App\Money\MoneyService ###
 
 ###> symfony/lock ###
 # Choose one of the stores below

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,7 +15,9 @@ services:
         App\Gateway\GatewayInterface:
             tags: ['app.gateway.gateway']
         App\Money\Currency\ExchangeInterface:
-            tags: ['app.lib.economy.currency.exchange']
+            tags: ['app.money.currency.exchange']
+        App\Money\Totalization\TotalizerInterface:
+            tags: ['app.money.totalization.totalizer']
         App\Matchfunding\Formula\FormulaInterface:
             tags: ['app.matchfunding.formula']
         App\Matchfunding\Rule\RuleInterface:
@@ -96,7 +98,11 @@ services:
 
     App\Money\Currency\ExchangeLocator:
         arguments:
-            - !tagged 'app.lib.economy.currency.exchange'
+            - !tagged 'app.money.currency.exchange'
+
+    App\Money\Totalization\TotalizerLocator:
+        arguments:
+            - !tagged 'app.money.totalization.totalizer'
 
     App\Mapping\AutoMapper:
         arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -96,6 +96,10 @@ services:
             $hosts:
                 - 'peertube.plataformess.org'
 
+    App\Money\MoneyService:
+        arguments:
+            - '%env(CURRENCY_DEFAULT)%'
+
     App\Money\Currency\ExchangeLocator:
         arguments:
             - !tagged 'app.money.currency.exchange'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -96,6 +96,10 @@ services:
             $hosts:
                 - 'peertube.plataformess.org'
 
+    App\State\MoneyTotalStateProvider:
+        arguments:
+            - !tagged 'api_platform.doctrine.orm.query_extension.collection'
+
     App\Money\MoneyService:
         arguments:
             - '%env(CURRENCY_DEFAULT)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,8 +14,8 @@ services:
     _instanceof:
         App\Gateway\GatewayInterface:
             tags: ['app.gateway.gateway']
-        App\Money\Currency\ExchangeInterface:
-            tags: ['app.money.currency.exchange']
+        App\Money\Conversion\ExchangeInterface:
+            tags: ['app.money.conversion.exchange']
         App\Money\Totalization\TotalizerInterface:
             tags: ['app.money.totalization.totalizer']
         App\Matchfunding\Formula\FormulaInterface:
@@ -100,9 +100,9 @@ services:
         arguments:
             - '%env(CURRENCY_DEFAULT)%'
 
-    App\Money\Currency\ExchangeLocator:
+    App\Money\Conversion\ExchangeLocator:
         arguments:
-            - !tagged 'app.money.currency.exchange'
+            - !tagged 'app.money.conversion.exchange'
 
     App\Money\Totalization\TotalizerLocator:
         arguments:

--- a/src/ApiResource/ApiMoney.php
+++ b/src/ApiResource/ApiMoney.php
@@ -2,6 +2,8 @@
 
 namespace App\ApiResource;
 
+use ApiPlatform\Metadata as API;
+use App\Money\Conversion\Conversion;
 use App\Money\MoneyInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -22,19 +24,28 @@ class ApiMoney implements MoneyInterface
     #[Assert\Currency()]
     public string $currency;
 
+    /**
+     * Conversion metadata.
+     */
+    #[API\ApiProperty(writable: false)]
+    public ?array $conversion;
+
     public function __construct(
         int $amount,
         string $currency,
+        ?Conversion $conversion = null,
     ) {
         $this->amount = $amount;
         $this->currency = $currency;
+        $this->conversion = $conversion?->toArray();
     }
 
     public static function of(MoneyInterface $moneyInterface): self
     {
         return new self(
             $moneyInterface->getAmount(),
-            $moneyInterface->getCurrency()
+            $moneyInterface->getCurrency(),
+            $moneyInterface->getConversion()
         );
     }
 
@@ -46,5 +57,12 @@ class ApiMoney implements MoneyInterface
     public function getCurrency(): string
     {
         return $this->currency;
+    }
+
+    public function getConversion(): ?Conversion
+    {
+        return $this->conversion
+            ? Conversion::fromArray($this->conversion)
+            : null;
     }
 }

--- a/src/ApiResource/Project/SupportApiResource.php
+++ b/src/ApiResource/Project/SupportApiResource.php
@@ -9,10 +9,9 @@ use App\ApiResource\Accounting\AccountingApiResource;
 use App\ApiResource\Accounting\TransactionApiResource;
 use App\ApiResource\ApiMoney;
 use App\Entity\Project\Support;
-use App\Mapping\Transformer\SupportMoneyMapTransformer;
 use App\State\ApiResourceStateProvider;
+use App\State\MoneyTotalStateProvider;
 use App\State\Project\SupportStateProcessor;
-use AutoMapper\Attribute\MapFrom;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -27,6 +26,11 @@ use Symfony\Component\Validator\Constraints as Assert;
     provider: ApiResourceStateProvider::class,
 )]
 #[API\GetCollection()]
+#[API\GetCollection(
+    uriTemplate: '/project_supports/money_total',
+    provider: MoneyTotalStateProvider::class,
+    paginationEnabled: false,
+)]
 #[API\Get()]
 #[API\Patch(
     security: 'is_granted("SUPPORT_EDIT", previous_object)',

--- a/src/ApiResource/Project/SupportApiResource.php
+++ b/src/ApiResource/Project/SupportApiResource.php
@@ -33,6 +33,22 @@ use Symfony\Component\Validator\Constraints as Assert;
     provider: MoneyTotalStateProvider::class,
     output: TotalizedMoney::class,
     paginationEnabled: false,
+    openapi: new \ApiPlatform\OpenApi\Model\Operation(
+        summary: 'Get money total',
+        description: 'Returns a single TotalizedMoney object',
+        responses: [
+            '200' => [
+                'description' => 'Totalized money',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            '$ref' => '#/components/schemas/ProjectSupport.TotalizedMoney',
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    )
 )]
 #[API\Get()]
 #[API\Patch(

--- a/src/ApiResource/Project/SupportApiResource.php
+++ b/src/ApiResource/Project/SupportApiResource.php
@@ -64,7 +64,6 @@ class SupportApiResource
     /**
      * The total monetary value of the Transactions going to the Project.
      */
-    #[MapFrom(Support::class, transformer: SupportMoneyMapTransformer::class)]
     public ApiMoney $money;
 
     /**

--- a/src/ApiResource/Project/SupportApiResource.php
+++ b/src/ApiResource/Project/SupportApiResource.php
@@ -10,6 +10,7 @@ use App\ApiResource\Accounting\AccountingApiResource;
 use App\ApiResource\Accounting\TransactionApiResource;
 use App\ApiResource\ApiMoney;
 use App\Entity\Project\Support;
+use App\Money\Totalization\TotalizedMoney;
 use App\State\ApiResourceStateProvider;
 use App\State\MoneyTotalStateProvider;
 use App\State\Project\SupportStateProcessor;
@@ -30,6 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[API\GetCollection(
     uriTemplate: '/project_supports/money_total',
     provider: MoneyTotalStateProvider::class,
+    output: TotalizedMoney::class,
     paginationEnabled: false,
 )]
 #[API\Get()]

--- a/src/Benzina/CheckoutsPump.php
+++ b/src/Benzina/CheckoutsPump.php
@@ -20,6 +20,8 @@ use App\Gateway\Gateway\DropGateway;
 use App\Gateway\Paypal\PaypalGateway;
 use App\Gateway\Stripe\StripeGateway;
 use App\Gateway\Wallet\WalletGateway;
+use App\Money\Money;
+use App\Money\MoneyService;
 use App\Repository\Project\ProjectRepository;
 use App\Repository\Project\SupportRepository;
 use App\Repository\TipjarRepository;
@@ -57,6 +59,7 @@ class CheckoutsPump implements PumpInterface
         private SupportRepository $supportRepository,
         private TipjarRepository $tipjarRepository,
         private CheckoutService $checkoutService,
+        private MoneyService $moneyService,
     ) {}
 
     public function supports(mixed $sample): bool
@@ -89,7 +92,7 @@ class CheckoutsPump implements PumpInterface
 
         $project = $this->getProject($record);
         $tipjar = $this->getPlatformTipjar();
-        $invested = new \DateTime($record['invested']);
+        $invested = new \DateTime($record['datetime'] ?? $record['invested']);
 
         $checkout = new Checkout();
         $checkout->setMigrated(true);
@@ -154,6 +157,7 @@ class CheckoutsPump implements PumpInterface
                 $support->setProject($project);
                 $support->setOrigin($checkout->getOrigin());
                 $support->addTransaction($transaction);
+                $support->setMoney($this->calcSupportMoney($support));
                 $support->setAnonymous($this->getSupportAnon($record, $support));
                 $support->setMessage($this->getSupportMessage($record, $support, $context));
 
@@ -231,6 +235,20 @@ class CheckoutsPump implements PumpInterface
         }
 
         return \sprintf("\n***\n%s", $msg['msg']);
+    }
+
+    private function calcSupportMoney(Support $support): EmbeddableMoney
+    {
+        $money = null;
+
+        foreach ($support->getTransactions() as $transaction) {
+            $money = $this->moneyService->add(
+                $transaction->getMoney(),
+                $money ?? new Money(0, $transaction->getMoney()->getCurrency())
+            );
+        }
+
+        return EmbeddableMoney::of($money);
     }
 
     private function getPlatformTipjar(): Tipjar

--- a/src/Benzina/InvestsPump.php
+++ b/src/Benzina/InvestsPump.php
@@ -31,12 +31,12 @@ use Goteo\Benzina\Pump\ArrayPumpTrait;
 use Goteo\Benzina\Pump\DoctrinePumpTrait;
 use Goteo\Benzina\Pump\PumpInterface;
 
-class CheckoutsPump implements PumpInterface
+class InvestsPump implements PumpInterface
 {
     use ArrayPumpTrait;
     use DatabasePumpTrait;
     use DoctrinePumpTrait;
-    use CheckoutsPumpTrait;
+    use InvestsPumpTrait;
 
     public const TRACKING_TITLE_V3 = 'v3 Invest ID';
     public const TRACKING_TITLE_PAYMENT = 'v3 Invest Payment';

--- a/src/Benzina/InvestsPumpTrait.php
+++ b/src/Benzina/InvestsPumpTrait.php
@@ -2,7 +2,7 @@
 
 namespace App\Benzina;
 
-trait CheckoutsPumpTrait
+trait InvestsPumpTrait
 {
     private const INVEST_KEYS = [
         'id',

--- a/src/Entity/Accounting/Accounting.php
+++ b/src/Entity/Accounting/Accounting.php
@@ -64,15 +64,6 @@ class Accounting
         return $accounting;
     }
 
-    public function __construct()
-    {
-        /*
-         * TO-DO: This property must be loaded from App's configuration,
-         * ideally a configuration that can be updated via a frontend, not env var only
-         */
-        $this->currency = 'EUR';
-    }
-
     public function getId(): ?int
     {
         return $this->id;

--- a/src/Entity/EmbeddableMoney.php
+++ b/src/Entity/EmbeddableMoney.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Money\Conversion\Conversion;
 use App\Money\MoneyInterface;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -27,19 +28,25 @@ class EmbeddableMoney implements MoneyInterface
     #[ORM\Column(type: 'string', nullable: true)]
     public readonly ?string $currency;
 
+    #[ORM\Column(type: 'json', nullable: true)]
+    private readonly ?array $conversion;
+
     public function __construct(
         ?int $amount = null,
         ?string $currency = null,
+        ?Conversion $conversion = null,
     ) {
         $this->amount = $amount;
         $this->currency = $currency;
+        $this->conversion = $conversion?->toArray();
     }
 
     public static function of(MoneyInterface $moneyInterface): self
     {
         return new self(
             $moneyInterface->getAmount(),
-            $moneyInterface->getCurrency()
+            $moneyInterface->getCurrency(),
+            $moneyInterface->getConversion()
         );
     }
 
@@ -51,5 +58,12 @@ class EmbeddableMoney implements MoneyInterface
     public function getCurrency(): string
     {
         return $this->currency;
+    }
+
+    public function getConversion(): ?Conversion
+    {
+        return $this->conversion
+            ? Conversion::fromArray($this->conversion)
+            : null;
     }
 }

--- a/src/Entity/Project/Support.php
+++ b/src/Entity/Project/Support.php
@@ -9,6 +9,7 @@ use App\Repository\Project\SupportRepository;
 use AutoMapper\Attribute\MapProvider;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[MapProvider(EntityMapProvider::class)]
@@ -42,7 +43,7 @@ class Support
     #[ORM\Column]
     private ?bool $anonymous = null;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Column(Types::TEXT, nullable: true)]
     private ?string $message = null;
 
     public function __construct()

--- a/src/Entity/Project/Support.php
+++ b/src/Entity/Project/Support.php
@@ -4,6 +4,7 @@ namespace App\Entity\Project;
 
 use App\Entity\Accounting\Accounting;
 use App\Entity\Accounting\Transaction;
+use App\Entity\EmbeddableMoney;
 use App\Mapping\Provider\EntityMapProvider;
 use App\Repository\Project\SupportRepository;
 use AutoMapper\Attribute\MapProvider;
@@ -11,6 +12,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Embedded;
 
 #[MapProvider(EntityMapProvider::class)]
 #[ORM\Table(name: 'project_support')]
@@ -39,6 +41,9 @@ class Support
     #[ORM\InverseJoinColumn(name: 'transaction_id', referencedColumnName: 'id')]
     #[ORM\ManyToMany(targetEntity: Transaction::class, cascade: ['persist'])]
     private Collection $transactions;
+
+    #[Embedded(class: EmbeddableMoney::class)]
+    private ?EmbeddableMoney $money = null;
 
     #[ORM\Column]
     private ?bool $anonymous = null;
@@ -100,6 +105,18 @@ class Support
     public function removeTransaction(Transaction $transaction): static
     {
         $this->transactions->removeElement($transaction);
+
+        return $this;
+    }
+
+    public function getMoney(): ?EmbeddableMoney
+    {
+        return $this->money;
+    }
+
+    public function setMoney(EmbeddableMoney $money): static
+    {
+        $this->money = $money;
 
         return $this;
     }

--- a/src/EventListener/AccountingDefaultsListener.php
+++ b/src/EventListener/AccountingDefaultsListener.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\EventListener;
+
+use App\Entity\Accounting\Accounting;
+use App\Money\MoneyService;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Events;
+
+#[AsEntityListener(
+    entity: Accounting::class,
+    method: 'prePersist',
+    event: Events::prePersist
+)]
+class AccountingDefaultsListener
+{
+    public function __construct(
+        private MoneyService $moneyService,
+    ) {}
+
+    public function prePersist(Accounting $accounting): void
+    {
+        if ($accounting->getCurrency() === null) {
+            $accounting->setCurrency($this->moneyService->getDefaultCurrency());
+        }
+    }
+}

--- a/src/EventListener/GatewayCheckoutSupportsListener.php
+++ b/src/EventListener/GatewayCheckoutSupportsListener.php
@@ -3,10 +3,14 @@
 namespace App\EventListener;
 
 use App\Entity\Accounting\Accounting;
+use App\Entity\Accounting\Transaction;
+use App\Entity\EmbeddableMoney;
 use App\Entity\Gateway\Charge;
 use App\Entity\Gateway\Checkout;
 use App\Entity\Project\Project;
 use App\Entity\Project\Support;
+use App\Money\Money;
+use App\Money\MoneyService;
 use App\Repository\Project\SupportRepository;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\EntityManagerInterface;
@@ -22,6 +26,7 @@ class GatewayCheckoutSupportsListener
 {
     public function __construct(
         private SupportRepository $supportRepository,
+        private MoneyService $moneyService,
     ) {}
 
     public function preFlush(Checkout $checkout, PreFlushEventArgs $args): void
@@ -48,31 +53,6 @@ class GatewayCheckoutSupportsListener
                 $uow->computeChangeSet($em->getClassMetadata(Support::class), $support);
             }
         }
-    }
-
-    /**
-     * Create ProjectSupport for the given data.
-     */
-    private function createSupport(Project $project, Accounting $origin, array $transactions): Support
-    {
-        $projectSupport = $this->supportRepository->findOneBy([
-            'project' => $project->getId(),
-            'origin' => $origin->getId(),
-        ]);
-
-        if (!$projectSupport) {
-            $projectSupport = new Support();
-        }
-
-        $projectSupport->setProject($project);
-        $projectSupport->setOrigin($origin);
-        $projectSupport->setAnonymous(false);
-
-        foreach ($transactions as $transaction) {
-            $projectSupport->addTransaction($transaction);
-        }
-
-        return $projectSupport;
     }
 
     /**
@@ -104,9 +84,42 @@ class GatewayCheckoutSupportsListener
 
         $supports = [];
         foreach ($transactionsByProject as $projectId => $transactions) {
-            $supports[] = $this->createSupport($projects[$projectId], $origin, $transactions);
+            $supports[] = $this->getSupport($projects[$projectId], $origin, $transactions);
         }
 
         return $supports;
+    }
+
+    /**
+     * Create ProjectSupport for the given data.
+     * 
+     * @param Transaction[] $transactions
+     */
+    private function getSupport(Project $project, Accounting $origin, array $transactions): Support
+    {
+        /** @var Support|null */
+        $projectSupport = $this->supportRepository->findOneBy([
+            'project' => $project->getId(),
+            'origin' => $origin->getId(),
+        ]);
+
+        if (!$projectSupport) {
+            $projectSupport = new Support();
+        }
+
+        $projectSupport->setProject($project);
+        $projectSupport->setOrigin($origin);
+        $projectSupport->setAnonymous(false);
+
+        $money = new Money(0, $project->getAccounting()->getCurrency());
+        foreach ($transactions as $transaction) {
+            $money = $this->moneyService->add($transaction->getMoney(), $money);
+
+            $projectSupport->addTransaction($transaction);
+        }
+
+        $projectSupport->setMoney(EmbeddableMoney::of($money));
+
+        return $projectSupport;
     }
 }

--- a/src/EventListener/GatewayCheckoutSupportsListener.php
+++ b/src/EventListener/GatewayCheckoutSupportsListener.php
@@ -92,7 +92,7 @@ class GatewayCheckoutSupportsListener
 
     /**
      * Create ProjectSupport for the given data.
-     * 
+     *
      * @param Transaction[] $transactions
      */
     private function getSupport(Project $project, Accounting $origin, array $transactions): Support

--- a/src/EventListener/TransactionCurrencyListener.php
+++ b/src/EventListener/TransactionCurrencyListener.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Entity\Accounting\Transaction;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\Events;
+
+#[AsEntityListener(
+    entity: Transaction::class,
+    event: Events::prePersist
+)]
+class TransactionCurrencyListener
+{
+    public function prePersist(Transaction $transaction): void
+    {
+        $money = $transaction->getMoney();
+        $target = $transaction->getTarget();
+
+        if ($money->getCurrency() !== $target->getCurrency()) {
+            throw new \LogicException(\sprintf(
+                "The Accounting with ID %s can only receive Transactions in %s currency. Please do a conversion operation before targeting an Accounting in a different currency.",
+                $target->getId(),
+                $target->getCurrency()
+            ));
+        }
+    }
+}

--- a/src/EventListener/TransactionCurrencyListener.php
+++ b/src/EventListener/TransactionCurrencyListener.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App\EventListener;
+
 use App\Entity\Accounting\Transaction;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Events;
@@ -17,7 +19,7 @@ class TransactionCurrencyListener
 
         if ($money->getCurrency() !== $target->getCurrency()) {
             throw new \LogicException(\sprintf(
-                "The Accounting with ID %s can only receive Transactions in %s currency. Please do a conversion operation before targeting an Accounting in a different currency.",
+                'The Accounting with ID %s can only receive Transactions in %s currency. Please do a conversion operation before targeting an Accounting in a different currency.',
                 $target->getId(),
                 $target->getCurrency()
             ));

--- a/src/Money/Conversion/Conversion.php
+++ b/src/Money/Conversion/Conversion.php
@@ -3,6 +3,7 @@
 namespace App\Money\Conversion;
 
 use App\Money\Money;
+use App\Money\MoneyInterface;
 use Brick\Math\RoundingMode;
 
 class Conversion
@@ -15,8 +16,8 @@ class Conversion
      * @param ?RoundingMode $roundingMode if supplied, then `rounding` will be set from here
      */
     public function __construct(
-        private Money $from,
-        private Money $to,
+        private MoneyInterface $from,
+        private MoneyInterface $to,
         private float $rate,
         private string $date,
         private string $provider,

--- a/src/Money/Conversion/Conversion.php
+++ b/src/Money/Conversion/Conversion.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Money\Conversion;
+
+use App\Money\Money;
+use Brick\Math\RoundingMode;
+
+class Conversion
+{
+    public const RoundingMode DEFAULT_ROUNDING = RoundingMode::UP;
+
+    private ?string $rounding = null;
+
+    /**
+     * @param ?RoundingMode $roundingMode if supplied, then `rounding` will be set from here
+     */
+    public function __construct(
+        private Money $from,
+        private Money $to,
+        private float $rate,
+        private string $date,
+        private string $provider,
+        ?string $rounding = null,
+        ?RoundingMode $roundingMode = null,
+    ) {
+        if ($rounding) {
+            $this->rounding = $rounding;
+        }
+
+        if ($roundingMode) {
+            $this->rounding = self::getRoundingName($roundingMode);
+        }
+
+        if ($this->rounding === null) {
+            throw new \Exception('Conversion rounding cannot be null');
+        }
+    }
+
+    /**
+     * @return Money the original Money that was converted from
+     */
+    public function getFrom(): Money
+    {
+        return $this->from;
+    }
+
+    /**
+     * @return Money the conversion result Money
+     */
+    public function getTo(): Money
+    {
+        return $this->to;
+    }
+
+    /**
+     * @return float the conversion rate given by the exchange rate provider
+     */
+    public function getRate(): float
+    {
+        return $this->rate;
+    }
+
+    /**
+     * @return string the date of the rate as given by the exchange rate provider
+     */
+    public function getDate(): string
+    {
+        return $this->date;
+    }
+
+    /**
+     * @return string the ExchangeInterface implementation name
+     */
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    /**
+     * @return string the rounding mode used during conversion
+     */
+    public function getRounding(): string
+    {
+        return $this->rounding;
+    }
+
+    public static function getRoundingName(RoundingMode $rounding): string
+    {
+        return match ($rounding) {
+            RoundingMode::UP => 'up',
+            RoundingMode::DOWN => 'down',
+            RoundingMode::FLOOR => 'floor',
+            RoundingMode::CEILING => 'ceiling',
+            RoundingMode::HALF_UP => 'half_up',
+            RoundingMode::HALF_DOWN => 'half_down',
+            RoundingMode::HALF_FLOOR => 'half_floor',
+            RoundingMode::HALF_CEILING => 'half_ceiling',
+            RoundingMode::HALF_EVEN => 'half_even',
+        };
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'from' => [
+                'amount' => $this->from->getAmount(),
+                'currency' => $this->from->getCurrency(),
+            ],
+            'to' => [
+                'amount' => $this->to->getAmount(),
+                'currency' => $this->to->getCurrency(),
+            ],
+            'rate' => $this->rate,
+            'date' => $this->date,
+            'provider' => $this->provider,
+            'rounding' => $this->rounding,
+        ];
+    }
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            from: new Money(
+                $data['from']['amount'],
+                $data['from']['currency']
+            ),
+            to: new Money(
+                $data['to']['amount'],
+                $data['to']['currency']
+            ),
+            rate: (float) $data['rate'],
+            date: $data['date'],
+            provider: $data['provider'],
+            rounding: $data['rounding'] ?? null,
+        );
+    }
+}

--- a/src/Money/Conversion/Exchange/AbstractExchange.php
+++ b/src/Money/Conversion/Exchange/AbstractExchange.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Money\Conversion\Exchange;
+
+use App\Money\Conversion\Conversion;
+use App\Money\Conversion\ExchangeInterface;
+use App\Money\Money;
+use App\Money\MoneyInterface;
+use App\Money\MoneyService;
+use Brick\Math\RoundingMode;
+use Brick\Money\Context;
+use Brick\Money\CurrencyConverter;
+use Brick\Money\ExchangeRateProvider;
+
+abstract class AbstractExchange implements ExchangeInterface
+{
+    protected string $date;
+
+    protected CurrencyConverter $converter;
+    protected ExchangeRateProvider $provider;
+
+    public function convert(
+        MoneyInterface $from,
+        string $toCurrency,
+        ?Context $context = null,
+        RoundingMode $roundingMode = RoundingMode::UP,
+    ): MoneyInterface {
+        $converted = $this->converter->convert(
+            MoneyService::toBrick($from),
+            $toCurrency,
+            $context,
+            $roundingMode
+        );
+
+        return new Money(
+            $converted->getMinorAmount()->toInt(),
+            $converted->getCurrency()->getCurrencyCode(),
+            new Conversion(
+                $from,
+                MoneyService::toMoney($converted),
+                rate: $this->getConversionRate($from->getCurrency(), $toCurrency),
+                date: $this->getConversionDate($from->getCurrency(), $toCurrency),
+                provider: $this->getName(),
+                roundingMode: $roundingMode
+            )
+        );
+    }
+
+    public function getConversionRate(string $fromCurrency, string $toCurrency): float
+    {
+        return $this->provider->getExchangeRate($fromCurrency, $toCurrency)->toFloat();
+    }
+
+    public function getConversionDate(string $fromCurrency, string $toCurrency): string
+    {
+        return $this->date;
+    }
+}

--- a/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
+++ b/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
@@ -7,6 +7,7 @@ use App\Money\Money;
 use App\Money\MoneyInterface;
 use App\Money\MoneyService;
 use Brick\Math\RoundingMode;
+use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
 use Brick\Money\ExchangeRateProvider;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
@@ -73,13 +74,17 @@ class EuropeanCentralBankExchange implements ExchangeInterface
         return self::WEIGHT;
     }
 
-    public function convert(MoneyInterface $money, string $toCurrency): MoneyInterface
-    {
+    public function convert(
+        MoneyInterface $money,
+        string $toCurrency,
+        ?Context $context = null,
+        RoundingMode $roundingMode = RoundingMode::UP,
+    ): MoneyInterface {
         $converted = $this->converter->convert(
             MoneyService::toBrick($money),
             $toCurrency,
-            null,
-            RoundingMode::HALF_EVEN
+            $context,
+            $roundingMode
         );
 
         return new Money(

--- a/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
+++ b/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Money\Currency;
+namespace App\Money\Conversion\Exchange;
 
+use App\Money\Conversion\ExchangeInterface;
 use App\Money\Money;
 use App\Money\MoneyInterface;
 use App\Money\MoneyService;

--- a/src/Money/Conversion/Exchange/FrankfurterExchange.php
+++ b/src/Money/Conversion/Exchange/FrankfurterExchange.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Money\Currency;
+namespace App\Money\Conversion\Exchange;
 
+use App\Money\Conversion\ExchangeInterface;
 use App\Money\Money;
 use App\Money\MoneyInterface;
 use App\Money\MoneyService;

--- a/src/Money/Conversion/Exchange/FrankfurterExchange.php
+++ b/src/Money/Conversion/Exchange/FrankfurterExchange.php
@@ -2,29 +2,18 @@
 
 namespace App\Money\Conversion\Exchange;
 
-use App\Money\Conversion\ExchangeInterface;
-use App\Money\Money;
-use App\Money\MoneyInterface;
-use App\Money\MoneyService;
-use Brick\Math\RoundingMode;
-use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
-use Brick\Money\ExchangeRateProvider;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-class FrankfurterExchange implements ExchangeInterface
+class FrankfurterExchange extends AbstractExchange
 {
     private const NAME = 'frankfurter';
     private const WEIGHT = 200;
 
     private const ENDPOINT = 'https://api.frankfurter.dev/v1/latest';
     private const ISO_4217 = 'EUR';
-
-    private ExchangeRateProvider $provider;
-    private CurrencyConverter $converter;
-    private \DateTimeImmutable $date;
 
     public function getName(): string
     {
@@ -47,37 +36,8 @@ class FrankfurterExchange implements ExchangeInterface
             $provider->setExchangeRate(self::ISO_4217, $currency, $rate);
         }
 
-        $this->date = new \DateTimeImmutable($data['date']);
+        $this->date = $data['date'];
         $this->provider = new BaseCurrencyProvider($provider, self::ISO_4217);
         $this->converter = new CurrencyConverter($this->provider);
-    }
-
-    public function convert(
-        MoneyInterface $money,
-        string $toCurrency,
-        ?Context $context = null,
-        RoundingMode $roundingMode = RoundingMode::UP,
-    ): MoneyInterface {
-        $converted = $this->converter->convert(
-            MoneyService::toBrick($money),
-            $toCurrency,
-            $context,
-            $roundingMode
-        );
-
-        return new Money(
-            $converted->getMinorAmount()->toInt(),
-            $converted->getCurrency()->getCurrencyCode()
-        );
-    }
-
-    public function getConversionRate(string $fromCurrency, string $toCurrency): float
-    {
-        return $this->provider->getExchangeRate($fromCurrency, $toCurrency)->toFloat();
-    }
-
-    public function getConversionDate(string $fromCurrency, string $toCurrency): \DateTimeInterface
-    {
-        return $this->date;
     }
 }

--- a/src/Money/Conversion/Exchange/FrankfurterExchange.php
+++ b/src/Money/Conversion/Exchange/FrankfurterExchange.php
@@ -7,6 +7,7 @@ use App\Money\Money;
 use App\Money\MoneyInterface;
 use App\Money\MoneyService;
 use Brick\Math\RoundingMode;
+use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
 use Brick\Money\ExchangeRateProvider;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
@@ -51,13 +52,17 @@ class FrankfurterExchange implements ExchangeInterface
         $this->converter = new CurrencyConverter($this->provider);
     }
 
-    public function convert(MoneyInterface $money, string $toCurrency): MoneyInterface
-    {
+    public function convert(
+        MoneyInterface $money,
+        string $toCurrency,
+        ?Context $context = null,
+        RoundingMode $roundingMode = RoundingMode::UP,
+    ): MoneyInterface {
         $converted = $this->converter->convert(
             MoneyService::toBrick($money),
             $toCurrency,
-            null,
-            RoundingMode::HALF_EVEN
+            $context,
+            $roundingMode
         );
 
         return new Money(

--- a/src/Money/Conversion/ExchangeInterface.php
+++ b/src/Money/Conversion/ExchangeInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Money\Currency;
+namespace App\Money\Conversion;
 
 use App\Money\MoneyInterface;
 use Brick\Money\Exception\CurrencyConversionException;

--- a/src/Money/Conversion/ExchangeInterface.php
+++ b/src/Money/Conversion/ExchangeInterface.php
@@ -20,7 +20,7 @@ interface ExchangeInterface
     public function getWeight(): int;
 
     /**
-     * @param MoneyInterface $money      The money to be converted
+     * @param MoneyInterface $from       The money to be converted
      * @param string         $toCurrency The currency to convert to
      *
      * @return MoneyInterface The converted MoneyInterface
@@ -28,7 +28,7 @@ interface ExchangeInterface
      * @throws CurrencyConversionException If the exchange rate is not available
      */
     public function convert(
-        MoneyInterface $money,
+        MoneyInterface $from,
         string $toCurrency,
         ?Context $context = null,
         RoundingMode $roundingMode = RoundingMode::UP,
@@ -48,9 +48,9 @@ interface ExchangeInterface
      * @param string $fromCurrency The currency to convert from
      * @param string $toCurrency   The currency to convert to
      *
-     * @return \DateTimeInterface The date and time at which the rate was last updated
+     * @return string The date and time at which the rate was last updated as given by the rate provider
      *
      * @throws CurrencyConversionException If the exchange rate is not available
      */
-    public function getConversionDate(string $fromCurrency, string $toCurrency): \DateTimeInterface;
+    public function getConversionDate(string $fromCurrency, string $toCurrency): string;
 }

--- a/src/Money/Conversion/ExchangeInterface.php
+++ b/src/Money/Conversion/ExchangeInterface.php
@@ -3,6 +3,8 @@
 namespace App\Money\Conversion;
 
 use App\Money\MoneyInterface;
+use Brick\Math\RoundingMode;
+use Brick\Money\Context;
 use Brick\Money\Exception\CurrencyConversionException;
 
 interface ExchangeInterface
@@ -25,7 +27,12 @@ interface ExchangeInterface
      *
      * @throws CurrencyConversionException If the exchange rate is not available
      */
-    public function convert(MoneyInterface $money, string $toCurrency): MoneyInterface;
+    public function convert(
+        MoneyInterface $money,
+        string $toCurrency,
+        ?Context $context = null,
+        RoundingMode $roundingMode = RoundingMode::UP,
+    ): MoneyInterface;
 
     /**
      * @param string $fromCurrency The currency to convert from

--- a/src/Money/Conversion/ExchangeLocator.php
+++ b/src/Money/Conversion/ExchangeLocator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Money\Currency;
+namespace App\Money\Conversion;
 
 use Brick\Money\Exception\CurrencyConversionException;
 

--- a/src/Money/Money.php
+++ b/src/Money/Money.php
@@ -2,11 +2,14 @@
 
 namespace App\Money;
 
+use App\Money\Conversion\Conversion;
+
 class Money implements MoneyInterface
 {
     public function __construct(
         private int $amount,
         private string $currency,
+        private ?Conversion $conversion = null,
     ) {}
 
     public function getAmount(): int
@@ -17,5 +20,10 @@ class Money implements MoneyInterface
     public function getCurrency(): string
     {
         return $this->currency;
+    }
+
+    public function getConversion(): ?Conversion
+    {
+        return $this->conversion;
     }
 }

--- a/src/Money/MoneyInterface.php
+++ b/src/Money/MoneyInterface.php
@@ -2,6 +2,8 @@
 
 namespace App\Money;
 
+use App\Money\Conversion\Conversion;
+
 interface MoneyInterface
 {
     /**
@@ -13,4 +15,9 @@ interface MoneyInterface
      * @return string 3-letter ISO 4217 currency code
      */
     public function getCurrency(): string;
+
+    /**
+     * @return Conversion|null If this Money is the result of a currency conversion operation. Else null.
+     */
+    public function getConversion(): ?Conversion;
 }

--- a/src/Money/MoneyService.php
+++ b/src/Money/MoneyService.php
@@ -8,8 +8,14 @@ use Brick\Money\Money as BrickMoney;
 class MoneyService
 {
     public function __construct(
+        private string $defaultCurrency,
         private ExchangeLocator $exchangeLocator,
     ) {}
+
+    public function getDefaultCurrency(): string
+    {
+        return $this->defaultCurrency;
+    }
 
     public static function toMoney(BrickMoney $brick): Money
     {

--- a/src/Money/MoneyService.php
+++ b/src/Money/MoneyService.php
@@ -2,7 +2,7 @@
 
 namespace App\Money;
 
-use App\Money\Currency\ExchangeLocator;
+use App\Money\Conversion\ExchangeLocator;
 use Brick\Money\Money as BrickMoney;
 
 class MoneyService

--- a/src/Money/Totalization/TotalizedMoney.php
+++ b/src/Money/Totalization/TotalizedMoney.php
@@ -2,10 +2,7 @@
 
 namespace App\Money\Totalization;
 
-use App\Money\Conversion\Conversion;
-use App\Money\MoneyInterface;
-
-class TotalizedMoney implements MoneyInterface
+class TotalizedMoney
 {
     public function __construct(
         private int $amount,
@@ -21,11 +18,6 @@ class TotalizedMoney implements MoneyInterface
     public function getCurrency(): string
     {
         return $this->currency;
-    }
-
-    public function getConversion(): ?Conversion
-    {
-        return null;
     }
 
     /**

--- a/src/Money/Totalization/TotalizedMoney.php
+++ b/src/Money/Totalization/TotalizedMoney.php
@@ -2,6 +2,7 @@
 
 namespace App\Money\Totalization;
 
+use App\Money\Conversion\Conversion;
 use App\Money\MoneyInterface;
 
 class TotalizedMoney implements MoneyInterface
@@ -20,6 +21,11 @@ class TotalizedMoney implements MoneyInterface
     public function getCurrency(): string
     {
         return $this->currency;
+    }
+
+    public function getConversion(): ?Conversion
+    {
+        return null;
     }
 
     /**

--- a/src/Money/Totalization/TotalizedMoney.php
+++ b/src/Money/Totalization/TotalizedMoney.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Money\Totalization;
+
+use App\Money\MoneyInterface;
+
+class TotalizedMoney implements MoneyInterface
+{
+    public function __construct(
+        private int $amount,
+        private string $currency,
+        private int $length,
+    ) {}
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    /**
+     * @return int the total number of items that were totalized to produce the Money
+     */
+    public function getLength(): int
+    {
+        return $this->length;
+    }
+}

--- a/src/Money/Totalization/Totalizer/SupportTotalizer.php
+++ b/src/Money/Totalization/Totalizer/SupportTotalizer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Money\Totalization\Totalizer;
+
+use App\Entity\Project\Support;
+use App\Money\Money;
+use App\Money\MoneyService;
+use App\Money\Totalization\TotalizedMoney;
+use App\Money\Totalization\TotalizerInterface;
+
+class SupportTotalizer implements TotalizerInterface
+{
+    public function __construct(
+        private MoneyService $moneyService,
+    ) {}
+
+    public static function getSupportedResource(): string
+    {
+        return Support::class;
+    }
+
+    /**
+     * @param iterable<int, Support> $items
+     */
+    public function totalize(iterable $items): TotalizedMoney
+    {
+        $length = 0;
+        $money = null;
+
+        foreach ($items as $support) {
+            ++$length;
+            $money = $this->moneyService->add(
+                $support->getMoney(),
+                $money ?? new Money(0, 'EUR')
+            );
+        }
+
+        return new TotalizedMoney($money->getAmount(), 'EUR', $length);
+    }
+}

--- a/src/Money/Totalization/TotalizerInterface.php
+++ b/src/Money/Totalization/TotalizerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Money\Totalization;
+
+interface TotalizerInterface
+{
+    /**
+     * @return string the resource that can be totalized by this Totalizer
+     */
+    public static function getSupportedResource(): string;
+
+    /**
+     * @param array $filters an array of filters to be applied to the resource Collection
+     */
+    public function totalize(array $filters): TotalizedMoney;
+}

--- a/src/Money/Totalization/TotalizerInterface.php
+++ b/src/Money/Totalization/TotalizerInterface.php
@@ -10,7 +10,7 @@ interface TotalizerInterface
     public static function getSupportedResource(): string;
 
     /**
-     * @param array $filters an array of filters to be applied to the resource Collection
+     * @param iterable $items The resource Collection
      */
-    public function totalize(array $filters): TotalizedMoney;
+    public function totalize(iterable $items): TotalizedMoney;
 }

--- a/src/Money/Totalization/TotalizerLocator.php
+++ b/src/Money/Totalization/TotalizerLocator.php
@@ -5,7 +5,7 @@ namespace App\Money\Totalization;
 class TotalizerLocator
 {
     /** @var array<string, TotalizerInterface> */
-    private array $totalizers;
+    private array $totalizers = [];
 
     public function __construct(
         iterable $interfaces,

--- a/src/Money/Totalization/TotalizerLocator.php
+++ b/src/Money/Totalization/TotalizerLocator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Money\Totalization;
+
+class TotalizerLocator
+{
+    /** @var array<string, TotalizerInterface> */
+    private array $totalizers;
+
+    public function __construct(
+        iterable $interfaces,
+    ) {
+        /** @var TotalizerInterface[] */
+        $totalizers = \iterator_to_array($interfaces);
+
+        foreach ($totalizers as $totalizer) {
+            $resource = $totalizer::getSupportedResource();
+
+            if (\array_key_exists($resource, $this->totalizers)) {
+                throw new \Exception(\sprintf(
+                    "Duplicated TotalizerInterface. The resource '%s' is already supported by %s",
+                    $resource,
+                    $totalizers[$resource]::class
+                ));
+            }
+
+            $this->totalizers[$resource] = $totalizer;
+        }
+    }
+
+    public function get(string $resource): ?TotalizerInterface
+    {
+        return $this->totalizers[$resource] ?? null;
+    }
+
+    /**
+     * @return array<string, TotalizerInterface>
+     */
+    public function getAll(): array
+    {
+        return $this->totalizers;
+    }
+}

--- a/src/State/Gateway/CheckoutStateProcessor.php
+++ b/src/State/Gateway/CheckoutStateProcessor.php
@@ -7,9 +7,12 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use App\ApiResource\Gateway\CheckoutApiResource;
 use App\Dto\CheckoutUpdationDto;
+use App\Entity\EmbeddableMoney;
 use App\Entity\Gateway\Checkout;
 use App\Gateway\GatewayLocator;
 use App\Mapping\AutoMapper;
+use App\Money\Conversion\ExchangeLocator;
+use Brick\Money\Context\CustomContext;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 class CheckoutStateProcessor implements ProcessorInterface
@@ -17,8 +20,9 @@ class CheckoutStateProcessor implements ProcessorInterface
     public function __construct(
         #[Autowire(service: PersistProcessor::class)]
         private ProcessorInterface $innerProcessor,
-        private GatewayLocator $gatewayLocator,
         private AutoMapper $autoMapper,
+        private GatewayLocator $gatewayLocator,
+        private ExchangeLocator $exchangeLocator,
     ) {}
 
     /**
@@ -33,13 +37,31 @@ class CheckoutStateProcessor implements ProcessorInterface
         }
 
         $entity = $this->autoMapper->map($data, Checkout::class);
-        $entity = $this->innerProcessor->process($entity, $operation, $uriVariables, $context);
 
-        if ($data instanceof CheckoutApiResource) {
-            $entity = $this->gatewayLocator->get($data->gateway->name)->process($entity);
-            $entity = $this->innerProcessor->process($entity, $operation, $uriVariables, $context);
+        /** @var Checkout */
+        $checkout = $this->innerProcessor->process($entity, $operation, $uriVariables, $context);
+
+        if ($data instanceof CheckoutUpdationDto) {
+            return $this->autoMapper->map($checkout, CheckoutApiResource::class);
         }
 
-        return $this->autoMapper->map($entity, CheckoutApiResource::class);
+        foreach ($checkout->getCharges() as $charge) {
+            $fromCurrency = $charge->getMoney()->getCurrency();
+            $toCurrency = $charge->getTarget()->getCurrency();
+
+            if ($fromCurrency === $toCurrency) {
+                continue;
+            }
+
+            $exchange = $this->exchangeLocator->get($fromCurrency, $toCurrency);
+            $exchanged = $exchange->convert($charge->getMoney(), $toCurrency, new CustomContext(0, 1));
+
+            $charge->setMoney(EmbeddableMoney::of($exchanged));
+        }
+
+        $checkout = $this->gatewayLocator->get($data->gateway->name)->process($checkout);
+        $checkout = $this->innerProcessor->process($checkout, $operation, $uriVariables, $context);
+
+        return $this->autoMapper->map($checkout, CheckoutApiResource::class);
     }
 }

--- a/src/State/MoneyTotalStateProvider.php
+++ b/src/State/MoneyTotalStateProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Doctrine\Common\State\LinksHandlerLocatorTrait;
+use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
+use ApiPlatform\Doctrine\Orm\State\LinksHandlerTrait;
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
+use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\State\ProviderInterface;
+use App\Money\Totalization\TotalizedMoney;
+use App\Money\Totalization\TotalizerLocator;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
+
+class MoneyTotalStateProvider implements ProviderInterface
+{
+    use LinksHandlerLocatorTrait;
+    use LinksHandlerTrait;
+
+    /**
+     * @param QueryCollectionExtensionInterface[] $collectionExtensions
+     */
+    public function __construct(
+        private readonly iterable $collectionExtensions,
+        private TotalizerLocator $totalizerLocator,
+        private ManagerRegistry $managerRegistry,
+        private ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null,
+        private ?ContainerInterface $handleLinksLocator = null,
+    ) {}
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): TotalizedMoney
+    {
+        $entityClass = $operation->getClass();
+        if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {
+            $entityClass = $options->getEntityClass();
+        }
+
+        $totalizer = $this->totalizerLocator->get($entityClass);
+
+        return $totalizer->totalize($this->getItems($entityClass, $operation, $uriVariables, $context));
+    }
+
+    private function getItems(
+        string $entityClass,
+        Operation $operation,
+        array $uriVariables = [],
+        array $context = [],
+    ): iterable {
+        /** @var EntityManagerInterface $manager */
+        $manager = $this->managerRegistry->getManagerForClass($entityClass);
+
+        $repository = $manager->getRepository($entityClass);
+        if (!method_exists($repository, 'createQueryBuilder')) {
+            throw new RuntimeException('The repository class must have a "createQueryBuilder" method.');
+        }
+
+        $queryBuilder = $repository->createQueryBuilder('o');
+        $queryNameGenerator = new QueryNameGenerator();
+
+        $this->handleLinks($queryBuilder, $uriVariables, $queryNameGenerator, $context, $entityClass, $operation);
+
+        foreach ($this->collectionExtensions as $extension) {
+            $extension->applyToCollection($queryBuilder, $queryNameGenerator, $entityClass, $operation, $context);
+
+            if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($entityClass, $operation, $context)) {
+                foreach ($extension->getResult($queryBuilder, $entityClass, $operation, $context) as $item) {
+                    $manager->detach($item);
+
+                    yield $item;
+                }
+
+                return;
+            }
+        }
+
+        foreach ($queryBuilder->getQuery()->toIterable() as $item) {
+            $manager->detach($item);
+
+            yield $item;
+        }
+    }
+}

--- a/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
+++ b/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\Tests\Library\Economy\Currency;
+namespace App\Tests\Money\Conversion;
 
-use App\Money\Currency\EuropeanCentralBankExchange;
+use App\Money\Conversion\Exchange\EuropeanCentralBankExchange;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 

--- a/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
+++ b/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
@@ -3,6 +3,8 @@
 namespace App\Tests\Money\Conversion;
 
 use App\Money\Conversion\Exchange\EuropeanCentralBankExchange;
+use App\Money\Money;
+use Brick\Money\Context\CustomContext;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -31,5 +33,15 @@ class EuropeanCentralBankExchangeTest extends TestCase
         $this->assertIsArray($exchangeData);
         $this->assertArrayHasKey('Cube', $exchangeData);
         $this->assertArrayHasKey('@attributes', $exchangeData);
+    }
+
+    public function testConvertsWholeEuros()
+    {
+        $exchange = new EuropeanCentralBankExchange();
+        $context = new CustomContext(scale: 0, step: 1);
+
+        $this->assertEquals(100, $exchange->convert(new Money(100, 'JPY'), 'EUR', $context)->getAmount());
+        $this->assertEquals(100, $exchange->convert(new Money(150, 'JPY'), 'EUR', $context)->getAmount());
+        $this->assertEquals(100, $exchange->convert(new Money(700, 'CNY'), 'EUR', $context)->getAmount());
     }
 }

--- a/tests/Money/MoneyServiceTest.php
+++ b/tests/Money/MoneyServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Tests\Library\Economy;
+namespace App\Tests\Money;
 
 use App\Money\Money;
 use App\Money\MoneyService;


### PR DESCRIPTION
- [x] Laid out `TotalizerInterface` and `MoneyTotalStateProvider` to allow for dynamic totalization of money in collections of resources.
- [x] Updated Accounting's to receive default currency via env var.
- [x] Updated Transactions to disallow targeting Accountings in a different currency.
- [x] Added `Conversion` class to allow snapshots of Money conversion metadata.
- [x] Refactored `ExchangeInterface` and exchanges to use new `Conversion`, have leaner classes and more flexible argument parameters.
- [x] Other minor bug fixes. 
